### PR TITLE
Fix vbox::extension_pack

### DIFF
--- a/manifests/extension_pack.pp
+++ b/manifests/extension_pack.pp
@@ -46,12 +46,15 @@ class vbox::extension_pack(
       }
 
       # Install the Extension Pack with `VBoxManage`.
+      $escaped_version = inline_template(
+        "<%= scope['vbox::params::version'].gsub('.', '\.') %>"
+      )
       exec { 'extension_pack-install':
         command => "${vboxmanage} extpack install --replace ${pack}",
         path    => ['/bin', '/usr/bin'],
         user    => 'root',
         cwd     => $sys::root_home,
-        creates => $directory,
+        unless  => "${vboxmanage} list extpacks | grep -e '^Version:[[:space:]]*${escaped_version}$'",
         require => [Sys::Fetch['extension-pack'], Class['vbox']],
       }
     }


### PR DESCRIPTION
This PR fixes #1 by using the `unless` parameter instead of `creates` for the `exec` resource that installs the extension pack.  In addition, the checking command ensures that the extension pack matches the desired VirtualBox version. 
