### PR TITLE
Fix extension pack manifest string escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.17 (08/29/2016)
+
+BUG FIXES
+
+* Fix extension pack command escaping.
+
 ## 0.9.16 (11/13/2015)
 
 IMPROVEMENTS:

--- a/manifests/extension_pack.pp
+++ b/manifests/extension_pack.pp
@@ -47,7 +47,7 @@ class vbox::extension_pack(
 
       # Install the Extension Pack with `VBoxManage`.
       $escaped_version = inline_template(
-        "<%= scope['vbox::params::version'].gsub('.', '\.') %>"
+        "<%= scope['vbox::params::version'].gsub('.', '\\.') %>"
       )
       exec { 'extension_pack-install':
         command => "${vboxmanage} extpack install --replace ${pack}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "counsyl-vbox",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "author": "Counsyl, Inc.",
   "summary": "Puppet module for installing and configuring VirtualBox",
   "license": "Apache-2.0",


### PR DESCRIPTION
@jbronn @lucaswiman 

This PR fixes a string escaping bug in the `extension_pack` module.
## How this was tested
- Using this version of the module to install the virtual box extension pack.
