### PR TITLE
Vbox extension pack license agreement

### DIFF
--- a/files/extpack_expect_script
+++ b/files/extpack_expect_script
@@ -12,7 +12,7 @@ expect {
         send "y\r"
         expect eof
     }
-    eof {}
+    eof {}  # Handles the case where no license agreement prompt was given
 }
 catch wait codes
 exit [lindex $codes 3]  # 4th item is the return code of the spawned process

--- a/files/extpack_expect_script
+++ b/files/extpack_expect_script
@@ -1,0 +1,18 @@
+#!/usr/bin/expect -f
+
+# Says "y" to the license agreement that pops up when installing the extension
+# pack. Or if there is no license agreement, don't do anything.
+
+# All args are assumed to be part of the command to be spawned
+set cmd [lrange $argv 0 end]
+
+spawn {*}$cmd
+expect {
+    "Do you agree to these license terms and conditions (y/n)?" {
+        send "y\r"
+        expect eof
+    }
+    eof {}
+}
+catch wait codes
+exit [lindex $codes 3]  # 4th item is the return code of the spawned process


### PR DESCRIPTION
Oracle now gives us a license agreement to agree to during the extension pack install, which makes puppet fail. This uses `expect` to look for the agreement prompt and say `y` to it.

The other way to do this was to just pipe in `yes`, but this way seems safer in case they add additional prompts at some point in the future.

Related: https://github.com/counsyl/puppet-sys/pull/23

Testing
--------------
Tested in vagrant using the `vmhost` box