### PR TITLE
Extension pack license agreement argument

### DIFF
--- a/manifests/extension_pack.pp
+++ b/manifests/extension_pack.pp
@@ -26,12 +26,12 @@
 #  The path to the VBoxManage command, defaults to '/usr/bin/VBoxManage'.
 #
 class vbox::extension_pack(
-  $ensure               = 'present',
-  $source               = $vbox::params::extension_pack_url,
-  $pack                 = $vbox::params::extension_pack,
-  $directory            = $vbox::params::extension_pack_dir,
-  $vboxmanage           = $vbox::params::vboxmanage,
-  $extpack_license_hash,
+  $ensure                 = 'present',
+  $source                 = $vbox::params::extension_pack_url,
+  $pack                   = $vbox::params::extension_pack,
+  $directory              = $vbox::params::extension_pack_dir,
+  $vboxmanage             = $vbox::params::vboxmanage,
+  $license_agreement_hash,
 ) inherits vbox::params {
   case $ensure {
     'installed', 'present': {
@@ -51,7 +51,7 @@ class vbox::extension_pack(
         "<%= scope['vbox::params::version'].gsub('.', '\\.') %>"
       )
       exec { 'extension_pack-install':
-        command => "${vboxmanage} extpack install --replace ${pack} --accept-license=${extpack_license_hash}",
+        command => "${vboxmanage} extpack install --replace ${pack} --accept-license=${license_agreement_hash}",
         path    => ['/bin', '/usr/bin'],
         user    => 'root',
         cwd     => $sys::root_home,

--- a/manifests/extension_pack.pp
+++ b/manifests/extension_pack.pp
@@ -26,11 +26,12 @@
 #  The path to the VBoxManage command, defaults to '/usr/bin/VBoxManage'.
 #
 class vbox::extension_pack(
-  $ensure     = 'present',
-  $source     = $vbox::params::extension_pack_url,
-  $pack       = $vbox::params::extension_pack,
-  $directory  = $vbox::params::extension_pack_dir,
-  $vboxmanage = $vbox::params::vboxmanage,
+  $ensure               = 'present',
+  $source               = $vbox::params::extension_pack_url,
+  $pack                 = $vbox::params::extension_pack,
+  $directory            = $vbox::params::extension_pack_dir,
+  $vboxmanage           = $vbox::params::vboxmanage,
+  $extpack_license_hash,
 ) inherits vbox::params {
   case $ensure {
     'installed', 'present': {
@@ -50,7 +51,7 @@ class vbox::extension_pack(
         "<%= scope['vbox::params::version'].gsub('.', '\\.') %>"
       )
       exec { 'extension_pack-install':
-        command => "${vboxmanage} extpack install --replace ${pack}",
+        command => "${vboxmanage} extpack install --replace ${pack} --accept-license=${extpack_license_hash}",
         path    => ['/bin', '/usr/bin'],
         user    => 'root',
         cwd     => $sys::root_home,


### PR DESCRIPTION
@jdavisp3 
cc @tajmorton 
This replaces https://github.com/counsyl/puppet-vbox/pull/4

There is now a license agreement during install of the extension pack. This adds an argument that agrees to the license. 

Running the extpack install command manually gives: 
```
Do you agree to these license terms and conditions (y/n)? y

License accepted. For batch installaltion add
--accept-license=<hash>
to the VBoxManage command line.
```
I'm assuming the hash it spits out should be protected, so it will live in the hiera `automation-vmhost` role yaml file.

Testing
------------
Tested in vagrant using the `vmhost` box